### PR TITLE
8 feature sfgit diff ignoring metadata files

### DIFF
--- a/sf_git/cli.py
+++ b/sf_git/cli.py
@@ -240,6 +240,15 @@ def push_worksheets(
     )
 
 
+@click.command("diff")
+def diff():
+    """
+    Displays unstaged changes on worksheets
+    """
+
+    sf_git.commands.diff_procedure(logger=click.echo)
+
+
 @click.group()
 @click.version_option(sf_git.__version__)
 @click.pass_context
@@ -252,6 +261,7 @@ cli.add_command(config_repo)
 cli.add_command(fetch_worksheets)
 cli.add_command(commit)
 cli.add_command(push_worksheets)
+cli.add_command(diff)
 
 if __name__ == "__main__":
     cli()

--- a/sf_git/git_utils.py
+++ b/sf_git/git_utils.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import List, Type, Union, Dict, Optional
 
+import git
 from git.objects.blob import Blob
 from git.objects.tree import Tree
 from git.repo.base import Repo
@@ -67,3 +68,28 @@ def get_blobs_content(blobs: List[Blob]) -> Dict[str, bytes]:
         b.name: b.data_stream.read() for b in blobs if isinstance(b, Blob)
     }
     return contents
+
+
+def diff(
+        repo: git.Repo,
+        subdirectory: Union[str, Path] = None,
+        file_extensions: Union[str, List[str]] = None
+) -> str:
+    """
+    Get git diff output with subdirectory and file extension filters
+
+    :param repo: git repository
+    :param subdirectory: only on files within this subdirectory
+    :param file_extensions: only match files with these extensions
+
+    :returns: str, git diff output
+    """
+    # Check input
+
+    # Get blobs
+
+    # Get git diff output
+
+    # Add coloring
+
+    return "ToDo"


### PR DESCRIPTION
# New Feature

🆕  **_sfgit diff_ command:** displays git diff output for worksheets only files

### Usage
```bash
$ sfgit diff
# diff --git a/worksheets/Getting_Started_Tutorials/[Template]_Adding_a_user_and_granting_roles.sql # b/worksheets/Getting_Started_Tutorials/[Template]_Adding_a_user_and_granting_roles.sql
# index 24efc36..8e0e89b 100644
# --- a/worksheets/Getting_Started_Tutorials/[Template]_Adding_a_user_and_granting_roles.sql
# +++ b/worksheets/Getting_Started_Tutorials/[Template]_Adding_a_user_and_granting_roles.sql
# @@ -1,5 +1,6 @@
#  /*--
#  In this Worksheet we will walk through creating a User in Snowflake.
# +// modified
```