### PR TITLE
Fix  command line part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For example, eastus2 for Azure should actually be east-us-2.
 
 **Import user worksheet locally** :
 ```bash
-$ sfgit fetch -username tdambrin -account-id my_account.west-europe.azure --auth-mode SSO
+$ sfgit fetch --username tdambrin --account-id my_account.west-europe.azure --auth-mode SSO
 ```
 
 **Commit you worksheets** (or through git commands for more flexibility) :


### PR DESCRIPTION
sfgit fetch fails due to missing - in command line
```shellscript
poetry run sfgit fetch -username test --account-id hoge.ap-northeast-1.aws --auth-mode SSO
loading dotenv from /Users/TrsNium/Library/Caches/pypoetry/virtualenvs/snowflake-Dk0TFyNw-py3.10/lib/python3.10/site-packages/sf_git/sf_git.conf
Usage: sfgit fetch [OPTIONS]
Try 'sfgit fetch --help' for help.

Error: Got unexpected extra argument (test)

```